### PR TITLE
Fix for entrypoint in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ RUN rm -rf /opt/waf-bypass/venv; python3 -m venv /opt/waf-bypass/venv
 RUN /opt/waf-bypass/venv/bin/python3 -m pip install -r /opt/waf-bypass/requirements.txt
 RUN chmod +x /opt/waf-bypass/main.py
 
-ENTRYPOINT ["/opt/waf-bypass/venv/bin/python3 /opt/waf-bypass/main.py"]
+ENTRYPOINT ["/opt/waf-bypass/venv/bin/python3", "/opt/waf-bypass/main.py"]


### PR DESCRIPTION
Hi, guys! I wanted to use your tool, but I encountered an error:

docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "/opt/waf-bypass/venv/bin/python3 /opt/waf-bypass/main.py": stat /opt/waf-bypass/venv/bin/python3 /opt/waf-bypass/main.py: no such file or directory: unknown.

It seems that this is due to a typo in the entrypoint. I suggest the following fix.
