### PR TITLE
Update Dockerfile to Multi-Stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM debian:12.9
+### Build stage
+FROM debian:12.9 AS builder
 
 WORKDIR /opt/waf-bypass
 
@@ -13,4 +14,8 @@ RUN rm -rf /opt/waf-bypass/venv; python3 -m venv /opt/waf-bypass/venv
 RUN /opt/waf-bypass/venv/bin/python3 -m pip install -r /opt/waf-bypass/requirements.txt
 RUN chmod +x /opt/waf-bypass/main.py
 
+### Runtime stage
+FROM debian:12.7
+COPY --from=builder /opt/waf-bypass /opt/waf-bypass
+WORKDIR /opt/waf-bypass
 ENTRYPOINT ["/opt/waf-bypass/venv/bin/python3", "/opt/waf-bypass/main.py"]


### PR DESCRIPTION
Hi,

Thanks for maintaining waf-bypass. I represent a research group investigating [multi-stage builds](https://docs.docker.com/build/building/multi-stage/). We recently refactored your Dockerfile to a multi-stage Dockerfile and found that it brings the following benefits: 

✅ Reduced final image size (from 666MB to 144MB)  
✅ Minimized image vulnerabilities (verified via [Trivy](https://github.com/aquasecurity/trivy), from 992 to 77)  

We hope this small improvement to the Dockerfile will be useful to you :)

Thanks,